### PR TITLE
make Border size publicly mutable, fix some syntax in comments

### DIFF
--- a/src/renderer/buffer.rs
+++ b/src/renderer/buffer.rs
@@ -14,9 +14,8 @@ let mut buffer = Buffer::new(30, 30);
 
 // Render Hello World to the top left of the buffer
 render!(
-    buffer, {
-        (0, 0) => "Hello World!"
-    }
+    buffer, 
+    (0, 0) => [ "Hello World!" ]
 );
 ```
 

--- a/src/widgets/border.rs
+++ b/src/widgets/border.rs
@@ -15,7 +15,7 @@ pub struct Border {
 impl Border {
     pub const fn square(width: u16, height: u16) -> Border {
         Border {
-            size: vec2(width, height),
+            size: Vec2 { x: width, y: height },
             horizontal: "─",
             vertical: "│",
             top_right: "┐",

--- a/src/widgets/border.rs
+++ b/src/widgets/border.rs
@@ -15,7 +15,7 @@ pub struct Border {
 impl Border {
     pub const fn square(width: u16, height: u16) -> Border {
         Border {
-            size: Vec2(width, height),
+            size: vec2(width, height),
             horizontal: "─",
             vertical: "│",
             top_right: "┐",

--- a/src/widgets/border.rs
+++ b/src/widgets/border.rs
@@ -25,6 +25,7 @@ impl Border {
         }
     }
 
+    // this is slightly faster than re-allocating the Border struct
     pub fn set_size(&mut self, size: impl Into<Vec2>) {
         self.size = size.into();
     }
@@ -32,20 +33,20 @@ impl Border {
 }
 impl Render for Border {
     fn render(&self, loc: Vec2, buffer: &mut Buffer) -> Vec2 {
-        for y in (loc.y + 1)..(loc.y + self.height - 1) {
+        for y in (loc.y + 1)..(loc.y + self.size.y - 1) {
             buffer.set(vec2(loc.x, y), self.vertical);
-            buffer.set(vec2(loc.x + self.width - 1, y), self.vertical);
+            buffer.set(vec2(loc.x + self.size.x - 1, y), self.vertical);
         }
 
         let _ = render!(buffer,
-            loc => [self.top_left, self.horizontal.repeat(self.width as usize - 2), self.top_right],
-            vec2(loc.x, loc.y + self.height - 1) => [self.bottom_left, self.horizontal.repeat(self.width as usize - 2), self.bottom_right]
+            loc => [self.top_left, self.horizontal.repeat(self.size.x as usize - 2), self.top_right],
+            vec2(loc.x, loc.y + self.size.y - 1) => [self.bottom_left, self.horizontal.repeat(self.size.x as usize - 2), self.bottom_right]
         );
 
         vec2(loc.x + 1, loc.y + 1)
     }
     fn size(&self) -> Vec2 {
-        vec2(self.width, self.height)
+        self.size
     }
 }
 

--- a/src/widgets/border.rs
+++ b/src/widgets/border.rs
@@ -3,8 +3,7 @@ use crate::prelude::*;
 /// A basic border type.
 /// Rendering this will put the next content inside of the function
 pub struct Border {
-    width: u16,
-    height: u16,
+    size: Vec2,
     horizontal: &'static str,
     vertical: &'static str,
     top_left: &'static str,
@@ -16,8 +15,7 @@ pub struct Border {
 impl Border {
     pub const fn square(width: u16, height: u16) -> Border {
         Border {
-            width,
-            height,
+            size: Vec2(width, height),
             horizontal: "─",
             vertical: "│",
             top_right: "┐",
@@ -26,6 +24,11 @@ impl Border {
             bottom_right: "┘",
         }
     }
+
+    pub fn set_size(&mut self, size: impl Into<Vec2>) {
+        self.size = size.into();
+    }
+
 }
 impl Render for Border {
     fn render(&self, loc: Vec2, buffer: &mut Buffer) -> Vec2 {

--- a/src/window.rs
+++ b/src/window.rs
@@ -37,9 +37,7 @@ let mut window = Window::init()?;
 
 render!(
     window,
-    [
-        (10, 10) => "Element Here!"
-    ]
+    (10, 10) => [ "Element Here!" ]
 )
 ```
 */


### PR DESCRIPTION
just adds a set_size function to Border since that's slightly cheaper than re-constructing the Border object repeatedly
(and fixes some comment examples cuz they had incorrect/inconsistent syntax)